### PR TITLE
Layout fixes

### DIFF
--- a/src/app/(pages)/recipes/_components/FoundRecipes.tsx
+++ b/src/app/(pages)/recipes/_components/FoundRecipes.tsx
@@ -15,10 +15,10 @@ const FoundRecipes = async ({ params, user }: Props) => {
   const totalPages = Math.max(1, Math.ceil(total / params.limit));
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col gap-2 rounded-md">
+    <section className="flex min-h-0 flex-1 flex-col gap-1 rounded-md">
       <ul className="flex min-h-0 flex-1 flex-col gap-2 overflow-auto px-1">
         {!recipes.length && (
-          <p className="text-c4">
+          <p className="bg-c2 text-c5 rounded-md p-1">
             {params.search ? "Hittade inga recept..." : "Här var det tomt..."}
           </p>
         )}

--- a/src/components/common/LogsTable.tsx
+++ b/src/components/common/LogsTable.tsx
@@ -129,9 +129,10 @@ const LogsTable = ({ logs, showUser = false }: Props) => {
     value: i.toString(),
     label: i.toString(),
   }));
+  const totalPages = Math.max(1, table.getPageCount());
 
   return (
-    <div className="bg-c3 flex max-h-full min-h-0 flex-1 flex-col">
+    <div className="bg-c3 flex h-full min-h-0 w-full flex-1 flex-col self-stretch">
       <div className="bg-c4 p-1">
         <Input
           value={globalFilter ?? ""}
@@ -140,17 +141,17 @@ const LogsTable = ({ logs, showUser = false }: Props) => {
           className="w-64 rounded border px-3 py-1 text-sm"
         />
       </div>
-      <div className="max-h-full min-h-0 overflow-auto">
-        <table className="min-w-full flex-1 border text-sm">
-          <thead className="sticky top-0 bg-gray-100 text-left">
+      <div className="bg-c4 border-c3 max-h-full min-h-0 flex-1 overflow-auto border-x border-b">
+        <table className="bg-c3 border-c3 min-w-full border-separate border-spacing-0 text-sm">
+          <thead className="bg-c3 text-left">
             {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id}>
+              <tr key={headerGroup.id} className="bg-c3">
                 {headerGroup.headers.map((header) => {
                   const ic = icon[header.column.getIsSorted() as string];
                   return (
                     <th
                       key={header.id}
-                      className="border-b p-2 font-semibold select-none"
+                      className="bg-c3 border-c3 sticky top-0 z-20 border-y p-2 font-semibold select-none"
                     >
                       {header.isPlaceholder ? null : (
                         <div
@@ -185,9 +186,12 @@ const LogsTable = ({ logs, showUser = false }: Props) => {
           </thead>
           <tbody>
             {table.getRowModel().rows.map((row) => (
-              <tr key={row.id} className="h-10 border-b">
+              <tr key={row.id}>
                 {row.getVisibleCells().map((cell) => (
-                  <td key={cell.id} className="p-2 align-top">
+                  <td
+                    key={cell.id}
+                    className="bg-c4 border-c3 h-10 border-b p-2 align-top"
+                  >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
                 ))}
@@ -196,25 +200,33 @@ const LogsTable = ({ logs, showUser = false }: Props) => {
           </tbody>
         </table>
       </div>
-      <div className="bg-c4 flex w-full items-center justify-between gap-2 p-2">
-        <Select
-          triggerClassName="w-24 h-8"
-          value={table.getState().pagination.pageSize.toString()}
-          onValueChange={(e) => table.setPageSize(Number(e))}
-          options={paginationOptions}
-        />
-        <div className="flex items-center gap-2">
-          <p>
-            {`Sida ${pagination.pageIndex + 1} av ${Math.ceil(logs.length / pagination.pageSize)}`}
+      <div className="bg-c3 flex shrink-0 items-center justify-between gap-2 p-1">
+        <div className="flex items-center gap-6">
+          <Select
+            triggerClassName="h-8 w-16"
+            value={table.getState().pagination.pageSize.toString()}
+            onValueChange={(e) => table.setPageSize(Number(e))}
+            options={paginationOptions}
+          />
+          <p className="text-xs">
+            Sida: {pagination.pageIndex + 1} av {totalPages}
           </p>
+        </div>
+        <div className="flex items-center gap-2">
           <Button
-            variant="ghost"
-            size="icon"
+            variant="outline"
+            disabled={!table.getCanPreviousPage()}
+            className="h-8 disabled:opacity-20"
             onClick={() => table.previousPage()}
           >
             <Icon icon="ChevronLeft" />
           </Button>
-          <Button variant="ghost" size="icon" onClick={() => table.nextPage()}>
+          <Button
+            variant="outline"
+            disabled={!table.getCanNextPage()}
+            className="h-8 disabled:opacity-20"
+            onClick={() => table.nextPage()}
+          >
             <Icon icon="ChevronRight" />
           </Button>
         </div>

--- a/src/components/common/RecipeView.tsx
+++ b/src/components/common/RecipeView.tsx
@@ -22,7 +22,7 @@ const RecipeView = ({
   return (
     <section className={cn("bg-c3 flex flex-col gap-4 p-2", className)}>
       <div className="bg-c2 border-c3 sticky top-0 z-10 flex items-center rounded-md border p-2">
-        <h1 className="text-c5 grow text-xl font-bold">
+        <h1 className="text-c5 flex-1 font-bold">
           <Link href={`/recipes/${id}`}>{name}</Link>
         </h1>
         {actions && actions}


### PR DESCRIPTION
LogsTable.tsx got the biggest update. The log table now fills available height/width more reliably, has a sticky header with explicit borders/backgrounds, keeps the footer from shrinking, disables previous/next pagination buttons when unavailable, and uses TanStack’s actual page count instead of deriving pages from raw logs.length.

FoundRecipes.tsx tightens the outer gap from gap-2 to gap-1, and makes the “no recipes found” text visible as a styled message with bg-c2 text-c5 rounded-md p-1.

RecipeView.tsx reduces the recipe title styling from text-xl grow to flex-1, so the title uses normal inherited size while still taking available space.